### PR TITLE
use self4j as logger interface

### DIFF
--- a/src/main/java/ir/limoo/driver/connection/LimooRequester.java
+++ b/src/main/java/ir/limoo/driver/connection/LimooRequester.java
@@ -10,6 +10,8 @@ import java.nio.file.Files;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.databind.JsonNode;
 
 import ir.limoo.driver.entity.User;
@@ -29,7 +31,7 @@ import okhttp3.Response;
 
 public class LimooRequester implements Closeable {
 
-	private static final transient org.apache.log4j.Logger logger = org.apache.log4j.Logger
+	private static final transient org.slf4j.Logger logger = LoggerFactory
 			.getLogger(LimooRequester.class);
 
 	private static final String LOGIN_URI = "j_spring_security_check";
@@ -62,7 +64,7 @@ public class LimooRequester implements Closeable {
 				return false;
 			}
 		} catch (IOException e) {
-			logger.error(e);
+			logger.error("", e);
 			return false;
 		}
 		return true;

--- a/src/main/java/ir/limoo/driver/connection/LimooWebsocketEndpoint.java
+++ b/src/main/java/ir/limoo/driver/connection/LimooWebsocketEndpoint.java
@@ -3,7 +3,6 @@ package ir.limoo.driver.connection;
 import java.io.Closeable;
 import java.io.IOException;
 
-import org.apache.log4j.Logger;
 import org.atmosphere.wasync.Client;
 import org.atmosphere.wasync.ClientFactory;
 import org.atmosphere.wasync.Decoder;
@@ -14,6 +13,8 @@ import org.atmosphere.wasync.Options;
 import org.atmosphere.wasync.Request;
 import org.atmosphere.wasync.RequestBuilder;
 import org.atmosphere.wasync.Socket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -27,7 +28,7 @@ import ir.limoo.driver.util.JacksonUtils;
 
 public class LimooWebsocketEndpoint implements Closeable {
 
-	private static final transient Logger logger = Logger.getLogger(LimooWebsocketEndpoint.class);
+	private static final transient Logger logger = LoggerFactory.getLogger(LimooWebsocketEndpoint.class);
 	
 	private static final String MESSAGE_CREATED_EVENT = "message_created";
 	private static final String AUTHENTICATION_FAILED_EVENT = "authentication_failed";
@@ -115,7 +116,7 @@ public class LimooWebsocketEndpoint implements Closeable {
 			try {
 				Thread.sleep(getNextConnectionAttemptDelay());
 			} catch (InterruptedException e1) {
-				logger.error(e1);
+				logger.error("", e1);
 			}
 		}
 	}

--- a/src/main/java/ir/limoo/driver/entity/Conversation.java
+++ b/src/main/java/ir/limoo/driver/entity/Conversation.java
@@ -6,7 +6,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -21,7 +22,7 @@ import ir.limoo.driver.util.JacksonUtils;
 
 public class Conversation {
 
-	private static final transient Logger logger = Logger.getLogger(Conversation.class);
+	private static final transient Logger logger = LoggerFactory.getLogger(Conversation.class);
 
 	@JsonProperty("my_membership")
 	private Membership membership;
@@ -143,7 +144,7 @@ public class Conversation {
 		try {
 			this.viewLog();
 		} catch (LimooException e) {
-			logger.error(e);
+			logger.error("", e);
 		}
 	}
 


### PR DESCRIPTION
استفاده مسقتیم از لاگ۴جی باعت میشه اگه کاربران این لایبرری از لاگر دیگری استفاده کنند با مشکل بر بخورن. لذا باید از سلف۴جی استفاده کنیم که انعطاف پذیرتر باشیم